### PR TITLE
Add support for CAS 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 CASLIB.PY
 =========
 
-A library to support OAuth, SAML, and CAS Clients as provided from a JASIG-CAS(3.5-4.0.0+) server
+A library to support OAuth, SAML, and CAS Clients as provided from a JASIG-CAS(3.5-5.0.0+) server
 
 Written in python using requests
 
@@ -10,14 +10,6 @@ _Requirements_
 - CAS Server
   - cas-server-support-oauth (Required for OAuth support)
   - cas-server-support-saml (Required for SAML support)
-
-AUTHOR
-======
-
-Steven Gregory - iPlant Collaborative © 2012-2015
-
-CONTACT: sgregory@iplantcollaborative.org
-
 
 PREFACE
 -------
@@ -275,7 +267,7 @@ OAuth Authentication is very similar to CAS Authentication, the difference is in
       #Exchange token for profile
       user_profile = oauth_client.get_profile(access_token)
 
-      if not user_profile or "id" not in user_profile:
+      if not user_profile or "username" not in user_profile:
           logger.error("AccessToken is producing an INVALID profile! "
                        "Check the CAS server and caslib.py for more information.")
           #NOTE: Make sure this redirects the user OUT of the loop!
@@ -283,7 +275,7 @@ OAuth Authentication is very similar to CAS Authentication, the difference is in
 
       #ASSERT: A valid OAuth token gave us the Users Profile.
       # Now create an AuthToken and return it
-      username = user_profile["id"]
+      username = user_profile["username"]
       #Implementation specific.. create an API token and return
       # it to the user...
       return HttpResponseRedirect("my.app.com/application")

--- a/caslib.py
+++ b/caslib.py
@@ -503,13 +503,11 @@ class OAuthClient():
         self.auth_prefix = auth_prefix
 
     def get_access_token(self, oauth_code):
-        validate_resp_map = self._validateCode(oauth_code)
-        if not validate_resp_map or 'access_token' not in validate_resp_map:
+        oauth_resp = self._validateCode(oauth_code)
+        if not oauth_resp or not oauth_resp.token or not oauth_resp.expires:
             return None, None
-        access_token = validate_resp_map['access_token'][0]
-        expires = int(validate_resp_map['expires'][0])
-        expiry_date = datetime.now() + timedelta(seconds=expires)
-        return access_token, expiry_date
+        expiry_date = datetime.now() + timedelta(seconds=oauth_resp.expires)
+        return oauth_resp.token, expiry_date
 
     def get_profile(self, access_token):
         """
@@ -570,7 +568,7 @@ class OAuthClient():
         # Use defaults if not set
         oauth_validate_url = self._access_token_url(code)
         oauth_resp = self.get_oauth_response(oauth_validate_url, "urlencoded")
-        return oauth_resp.map
+        return oauth_resp
 
 
 class OAuthResponse:

--- a/caslib.py
+++ b/caslib.py
@@ -523,7 +523,7 @@ class OAuthClient():
         oauth_resp = self.get_oauth_response(oauth_profile_url, "json")
         if 'error' in oauth_resp.map:
             raise Exception("Error occurred during call to %s - %s" % (oauth_profile_url, oauth_resp.map))
-        return oauth_resp.map
+        return oauth_resp.profile
 
     def logout(self, redirect):
         return self._logout_url(redirect)

--- a/caslib.py
+++ b/caslib.py
@@ -554,7 +554,7 @@ class OAuthClient():
                % (self.auth_prefix, service_url)
 
     def _login_url(self):
-        url = "%s%s/oauth2.0/authorize?client_id=%s&redirect_uri=%s" %\
+        url = "%s%s/oauth2.0/authorize?client_id=%s&response_type=code&redirect_uri=%s" %\
               (self.server_url, self.auth_prefix,
                self.client_id, self.callback_url)
         return url

--- a/caslib.py
+++ b/caslib.py
@@ -543,8 +543,9 @@ class OAuthClient():
                 % (self.server_url, self.auth_prefix, access_token)
 
     def _access_token_url(self, code):
-        return "%s%s/oauth2.0/accessToken?"\
-                "code=%s&client_id=%s&client_secret=%s&redirect_uri=%s"\
+        return "%s%s/oauth2.0/accessToken?" \
+                "code=%s&client_id=%s&client_secret=%s&redirect_uri=%s&" \
+                "grant_type=authorization_code" \
                 % (self.server_url, self.auth_prefix,
                    code, self.client_id, self.client_secret, self.callback_url)
 

--- a/caslib.py
+++ b/caslib.py
@@ -584,16 +584,25 @@ class OAuthResponse:
 
         if "access_token" in self.map:
             self.token = self.map['access_token'][0]
-            self.expires = int(self.map['expires'][0])
+
+        for key in ["expires", "expires_in"]:
+            if key in self.map:
+                self.expires = int(self.map.get(key)[0])
+                break
 
         if "id" in self.map:
             self._build_profile()
 
     def _build_profile(self):
         self.profile['username'] = self.map["id"]
-        for attr in self.map['attributes']:
-            for k, v in attr.items():
-                self.profile[k] = v
+        attributes = self.map['attributes']
+        if isinstance(attributes, list): # CAS 4
+            for attr in attributes:
+                if isinstance(attr, dict):
+                    for k, v in attr.items():
+                        self.profile[k] = v
+        elif isinstance(attributes, dict): # CAS 5
+            self.profile.update(attributes)
 
     def parse_response(self, response, mime_type):
         response_map = {}

--- a/caslib.py
+++ b/caslib.py
@@ -588,7 +588,7 @@ class OAuthResponse:
             self.expires = int(self.map['expires'][0])
 
         if "id" in self.map:
-            self.profile = self._build_profile()
+            self._build_profile()
 
     def _build_profile(self):
         self.profile['username'] = self.map["id"]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
-    
+
 setup(name='caslib.py',
-      version='2.2.2',
+      version='2.3.0',
       description='CAS Client library',
       author='iPlant Collaborative',
       author_email='atmodevs@gmail.com',


### PR DESCRIPTION
## Description
This changeset provides support for CAS 5

There are two primary classes that were affected: OAuthClient and OAuthResponse. OAuthResponse would directly talk to the CAS server and parse its response. OAuthClient would provide functionality on top of this lower level like getting a user's profile or validating an authorization token.

I found that there wasn't a great separation of concerns. The OAuthClient was reaching into the OAuthResponse's raw response. Since CAS 5 had some small cosmetic changes in its response shape, OAuthClient broke when it shouldn't have.

I made changes so that OAuthResponse could handle CAS 5 and then I adjusted OAuthClient to use the `profile` and `expires` attributes of the response rather than response.map which included the raw response.

django-cyverse-auth also reached into the response details in `get_profile`. Now  `get_profile` no longer returns the raw cas response. d-c-a will need be changed to not depend on the specifics of the api response and just use profile information.